### PR TITLE
Stateful Multigraph: Add Leaflet tile layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@targomo/js-extensions",
   "description": "Google and Leaflet JavaScript (& TypeScript) extensions for Targomo's time-based access mapping services.",
   "author": "Targomo",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "repository": "github:targomo/targomo-js-extensions",
   "homepage": "https://targomo.com/developers",
@@ -62,7 +62,7 @@
     "typescript": "^2.5.0"
   },
   "dependencies": {
-    "@targomo/core": "^0.2.14",
+    "@targomo/core": "^0.2.16",
     "@types/googlemaps": "^3.30.10",
     "@types/leaflet": "^1.2.8",
     "leaflet": "^1.3.1",

--- a/src/index.leaflet.ts
+++ b/src/index.leaflet.ts
@@ -1,3 +1,4 @@
 export * from './leaflet/polygonOverlay'
 export * from './leaflet/tileLayer'
 export * from './leaflet/multigraphTileLayer'
+export * from './leaflet/statefulMultigraphTileLayer'

--- a/src/leaflet/statefulMultigraphTileLayer.ts
+++ b/src/leaflet/statefulMultigraphTileLayer.ts
@@ -1,0 +1,55 @@
+import * as L from 'leaflet';
+import 'leaflet.vectorgrid/dist/Leaflet.VectorGrid.bundled.js';
+
+import { TargomoClient } from '@targomo/core';
+
+export class TgmLeafletStatefulMultigraphTileLayer {
+    tgmClient: TargomoClient;
+    layer: any;
+    map: L.Map;
+    multigraphId: string;
+    vectorTileoptions: {vectorTileLayerStyles: any};
+
+    constructor(
+        tgmClient: TargomoClient,
+        multigraphId: string,
+        vectorTileoptions: {vectorTileLayerStyles: any}) {
+
+        this.tgmClient = tgmClient;
+        this.update(multigraphId, vectorTileoptions);
+    }
+
+    async addTo(map: L.Map) {
+        if (!this.layer) {
+            await this.createLayer();
+        }
+        this.map = map;
+        this.layer.addTo(map);
+    }
+
+    update(
+        multigraphId?: string,
+        vectorTileoptions?: {vectorTileLayerStyles: any}
+    ): Promise<any>  {
+        if (multigraphId) {
+            this.multigraphId = multigraphId;
+        }
+        if (vectorTileoptions) {
+            this.vectorTileoptions = vectorTileoptions;
+        }
+
+        return this.createLayer();
+    }
+
+    async createLayer() {
+        if (this.map && this.layer) {
+            this.map.removeLayer(this.layer);
+        }
+        const url = await this.tgmClient.statefulMultigraph.getTiledMultigraphUrl(this.multigraphId, 'mvt');
+        this.layer = (L as any).vectorGrid.protobuf(url, this.vectorTileoptions);
+        if (this.map && this.layer) {
+            this.layer.addTo(this.map);
+        }
+        return;
+    }
+}


### PR DESCRIPTION
Add support for Stateful Multigraph result tiles as Leaflet layer.

This depends on https://github.com/targomo/targomo-js/pull/60 to be merged first.