### PR TITLE
Feature/build fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: code.route360.net:4567/docker/general-image/node10:0.0.6
+image: $CI_REGISTRY/docker/debian/node:10_ci
 
 variables:
   NODE_ENV: gitlab-ci

--- a/package.googlemaps.json
+++ b/package.googlemaps.json
@@ -4,7 +4,7 @@
   "main": "targomo-googlemaps.umd.min.js",
   "module": "targomo-googlemaps.umd.min.js",
   "browser": "targomo-googlemaps.umd.min.js",
-  "typings": "./typings/index.d.ts",
+  "typings": "./typings/index.googlemaps.d.ts",
   "dependencies": {
     "@targomo/core": "^0.2.3",
     "@types/googlemaps": "^3.30.10"

--- a/package.googlemaps.json
+++ b/package.googlemaps.json
@@ -1,8 +1,8 @@
 {
   "name": "@targomo/googlemaps",
   "description": "Google maps extensions for for Targomo's time-based access mapping services.",
-  "main": "targomo-googlemaps.js",
-  "module": "targomo-googlemaps.js",
+  "main": "targomo-googlemaps.umd.min.js",
+  "module": "targomo-googlemaps.umd.min.js",
   "browser": "targomo-googlemaps.umd.min.js",
   "typings": "./typings/index.d.ts",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "commute",
     "commute-time"
   ],
-  "main": "targomo-googlemaps.js",
-  "module": "targomo-googlemaps.js",
+  "main": "targomo-googlemaps.umd.js",
+  "module": "targomo-googlemaps.umd.js",
   "browser": "targomo-googlemaps.umd.min.js",
   "typings": "./typings/index.d.ts",
   "scripts": {

--- a/package.leaflet.json
+++ b/package.leaflet.json
@@ -1,8 +1,8 @@
 {
   "name": "@targomo/leaflet",
   "description": "Leaflet maps extensions for Targomo's time-based access mapping services.",
-  "main": "targomo-leaflet.js",
-  "module": "targomo-leaflet.js",
+  "main": "targomo-leaflet.umd.min.js",
+  "module": "targomo-leaflet.umd.min.js",
   "browser": "targomo-leaflet.umd.min.js",
   "typings": "./typings/index.d.ts",
   "dependencies": {

--- a/package.leaflet.json
+++ b/package.leaflet.json
@@ -4,7 +4,7 @@
   "main": "targomo-leaflet.umd.min.js",
   "module": "targomo-leaflet.umd.min.js",
   "browser": "targomo-leaflet.umd.min.js",
-  "typings": "./typings/index.d.ts",
+  "typings": "./typings/index.leaflet.d.ts",
   "dependencies": {
     "@targomo/core": "^0.2.3",
     "@types/leaflet": "^1.2.8",


### PR DESCRIPTION
Should allow correct importing of the `@targomo/googlemaps` and `@targomo/leafet` libs.